### PR TITLE
add i-vila example

### DIFF
--- a/papermage/magelib/__init__.py
+++ b/papermage/magelib/__init__.py
@@ -23,6 +23,7 @@ from papermage.magelib.document import (
     PagesFieldName, 
     TokensFieldName, 
     RowsFieldName,
+    BlocksFieldName,
     ImagesFieldName
 )
 
@@ -44,4 +45,5 @@ __all__ = [
     "PagesFieldName",
     "TokensFieldName",
     "RowsFieldName",
+    "BlocksFieldName"
 ]

--- a/papermage/magelib/document.py
+++ b/papermage/magelib/document.py
@@ -25,6 +25,7 @@ RelationsFieldName = "relations"
 PagesFieldName = "pages"
 TokensFieldName = "tokens"
 RowsFieldName = "rows"
+BlocksFieldName = "blocks"
 
 
 class Document:

--- a/papermage/predictors/__init__.py
+++ b/papermage/predictors/__init__.py
@@ -1,5 +1,8 @@
 from papermage.predictors.api_predictors.span_qa_predictor import APISpanQAPredictor
 from papermage.predictors.hf_predictors.bio_tagger_predictor import HFBIOTaggerPredictor
+from papermage.predictors.hf_predictors.vila_predictor import (
+    IVILATokenClassificationPredictor,
+)
 from papermage.predictors.lp_predictors.block_predictor import LPBlockPredictor
 
-__all__ = ["HFBIOTaggerPredictor", "APISpanQAPredictor", "LPBlockPredictor"]
+__all__ = ["HFBIOTaggerPredictor", "APISpanQAPredictor", "LPBlockPredictor", "IVILATokenClassificationPredictor"]

--- a/papermage/predictors/hf_predictors/vila_predictor.py
+++ b/papermage/predictors/hf_predictors/vila_predictor.py
@@ -120,7 +120,7 @@ def convert_document_page_to_pdf_dict(doc: Document, page_width: int, page_heigh
 
     token_data = [
         (
-            token.symbols[0],  # words
+            token.symbols_from_spans[0],  # words
             token.boxes[0].to_absolute(page_width=page_width, page_height=page_height).xy_coordinates,  # bbox
             get_visual_group_id(token, RowsFieldName, -1),  # line_ids
             get_visual_group_id(token, BlocksFieldName, -1),  # block_ids

--- a/papermage/predictors/hf_predictors/vila_predictor.py
+++ b/papermage/predictors/hf_predictors/vila_predictor.py
@@ -1,0 +1,261 @@
+"""
+
+This file rewrites the PDFPredictor classes in
+https://github.com/allenai/VILA/blob/dd242d2fcbc5fdcf05013174acadb2dc896a28c3/src/vila/predictors.py#L1
+to reduce the dependency on the VILA package.
+
+@shannons, @kylel
+
+"""
+
+
+import inspect
+import itertools
+from abc import abstractmethod
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import torch
+from tqdm import tqdm
+from vila.predictors import LayoutIndicatorPDFPredictor, SimplePDFPredictor
+
+from papermage.magelib import (
+    Annotation,
+    BlocksFieldName,
+    Document,
+    Entity,
+    Metadata,
+    PagesFieldName,
+    RowsFieldName,
+    Span,
+    TokensFieldName,
+)
+from papermage.predictors.base_predictor import BasePredictor
+
+# Two constants for the constraining the size of the page for
+# inputs to the model.
+# TODO: Move this to somewhere else.
+MAX_PAGE_WIDTH = 1000
+MAX_PAGE_HEIGHT = 1000
+
+
+# util
+def columns_used_in_model_inputs(model):
+    signature = inspect.signature(model.forward)
+    signature_columns = list(signature.parameters.keys())
+    return signature_columns
+
+
+# util
+def normalize_bbox(
+    bbox,
+    page_width,
+    page_height,
+    target_width,
+    target_height,
+):
+    """
+    Normalize bounding box to the target size.
+    """
+
+    x1, y1, x2, y2 = bbox
+
+    # Right now only execute this for only "large" PDFs
+    # TODO: Change it for all PDFs
+    if page_width > target_width or page_height > target_height:
+        x1 = float(x1) / page_width * target_width
+        x2 = float(x2) / page_width * target_width
+        y1 = float(y1) / page_height * target_height
+        y2 = float(y2) / page_height * target_height
+
+    return (x1, y1, x2, y2)
+
+
+# util
+def shift_index_sequence_to_zero_start(sequence):
+    """
+    Shift a sequence to start at 0.
+    """
+    sequence_start = min(sequence)
+    return [i - sequence_start for i in sequence]
+
+
+# util
+def get_visual_group_id(token: Entity, field_name: str, defaults=-1) -> int:
+    if not hasattr(token, field_name):
+        return defaults
+    field_value = getattr(token, field_name)
+    if len(field_value) == 0 or field_value[0].id is None:
+        return defaults
+    return field_value[0].id
+
+
+# util
+def convert_document_page_to_pdf_dict(doc: Document, page_width: int, page_height: int) -> Dict[str, List]:
+    """Convert a document to a dictionary of the form:
+        {
+            'words': ['word1', 'word2', ...],
+            'bbox': [[x1, y1, x2, y2], [x1, y1, x2, y2], ...],
+            'block_ids': [0, 0, 0, 1 ...],
+            'line_ids': [0, 1, 1, 2 ...],
+            'labels': [0, 0, 0, 1 ...], # could be empty
+        }
+
+    Args:
+        document (Document):
+            The input document object
+        page_width (int):
+            Typically the transformer model requires to use
+            the absolute coordinates for encoding the coordinates.
+            Set the correspnding page_width and page_height to convert the
+            relative coordinates to the absolute coordinates.
+        page_height (int):
+            Typically the transformer model requires to use
+            the absolute coordinates for encoding the coordinates.
+            Set the correspnding page_width and page_height to convert the
+            relative coordinates to the absolute coordinates.
+
+    Returns:
+        Dict[str, List]: The pdf_dict object
+    """
+
+    token_data = [
+        (
+            token.symbols[0],  # words
+            token.boxes[0].to_absolute(page_width=page_width, page_height=page_height).xy_coordinates,  # bbox
+            get_visual_group_id(token, RowsFieldName, -1),  # line_ids
+            get_visual_group_id(token, BlocksFieldName, -1),  # block_ids
+        )
+        for token in doc.tokens
+    ]
+
+    words, bbox, line_ids, block_ids = (list(l) for l in zip(*token_data))
+    line_ids = shift_index_sequence_to_zero_start(line_ids)
+    block_ids = shift_index_sequence_to_zero_start(block_ids)
+
+    labels = [None] * len(words)
+    # TODO: We provide an empty label list.
+
+    return {
+        "words": words,
+        "bbox": bbox,
+        "block_ids": block_ids,
+        "line_ids": line_ids,
+        "labels": labels,
+    }
+
+
+# util
+def convert_sequence_tagging_to_spans(
+    token_prediction_sequence: List,
+) -> List[Tuple[int, int, int]]:
+    """For a sequence of token predictions, convert them to spans
+    of consecutive same predictions.
+
+    Args:
+        token_prediction_sequence (List)
+
+    Returns:
+        List[Tuple[int, int, int]]: A list of (start, end, label)
+            of consecutive prediction of the same label.
+    """
+    prev_len = 0
+    spans = []
+    for gp, seq in itertools.groupby(token_prediction_sequence):
+        cur_len = len(list(seq))
+        spans.append((prev_len, prev_len + cur_len, gp))
+        prev_len = prev_len + cur_len
+    return spans
+
+
+class BaseSinglePageTokenClassificationPredictor(BasePredictor):
+    REQUIRED_BACKENDS = ["transformers", "torch", "vila"]
+    REQUIRED_DOCUMENT_FIELDS = [PagesFieldName, TokensFieldName]
+    DEFAULT_SUBPAGE_PER_RUN = 2  # TODO: Might remove this in the future for longformer-like models
+
+    @property
+    @abstractmethod
+    def VILA_MODEL_CLASS(self):
+        pass
+
+    def __init__(self, predictor, subpage_per_run: Optional[int] = None):
+        self.predictor = predictor
+
+        # TODO: Make this more robust
+        self.id2label = self.predictor.model.config.id2label
+        self.label2id = self.predictor.model.config.label2id
+
+        self.subpage_per_run = subpage_per_run or self.DEFAULT_SUBPAGE_PER_RUN
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        preprocessor=None,
+        device: Optional[str] = None,
+        subpage_per_run: Optional[int] = None,
+        **preprocessor_config,
+    ):
+        predictor = cls.VILA_MODEL_CLASS.from_pretrained(
+            model_path=model_name_or_path, preprocessor=preprocessor, device=device, **preprocessor_config
+        )
+
+        return cls(predictor, subpage_per_run)
+
+    def predict(self, doc: Document, subpage_per_run: Optional[int] = None) -> List[Annotation]:
+        page_prediction_results = []
+        for page_id, page in enumerate(tqdm(doc.pages)):
+            if page.tokens:
+                page_width, page_height = doc.images[page_id].pilimage.size
+
+                pdf_dict = self.preprocess(page, page_width=page_width, page_height=page_height)
+
+                model_predictions = self.predictor.predict(
+                    page_data=pdf_dict,
+                    page_size=(page_width, page_height),
+                    batch_size=subpage_per_run or self.subpage_per_run,
+                    return_type="list",
+                )
+
+                assert len(model_predictions) == len(
+                    page.tokens
+                ), f"Model predictions and tokens are not the same length ({len(model_predictions)} != {len(page.tokens)}) for page {page_id}"
+
+                page_prediction_results.extend(self.postprocess(page, model_predictions))
+
+        return page_prediction_results
+
+    def preprocess(self, page: Document, page_width: float, page_height: float) -> Dict:
+        # In the latest vila implementations (after 0.4.0), the predictor will
+        # handle all other preprocessing steps given the pdf_dict input format.
+
+        return convert_document_page_to_pdf_dict(page, page_width=page_width, page_height=page_height)
+
+    def postprocess(self, doc: Document, model_predictions) -> List[Entity]:
+        token_prediction_spans = convert_sequence_tagging_to_spans(model_predictions)
+
+        prediction_spans = []
+        for token_start, token_end, label in token_prediction_spans:
+            cur_spans = doc.tokens[token_start:token_end]
+
+            start = min([ele.start for ele in cur_spans])
+            end = max([ele.end for ele in cur_spans])
+            sg = Entity(spans=[Span(start, end)], metadata=Metadata(type=label))
+            prediction_spans.append(sg)
+        return prediction_spans
+
+
+class SinglePageTokenClassificationPredictor(BaseSinglePageTokenClassificationPredictor):
+    VILA_MODEL_CLASS = SimplePDFPredictor
+
+
+class IVILATokenClassificationPredictor(BaseSinglePageTokenClassificationPredictor):
+    VILA_MODEL_CLASS = LayoutIndicatorPDFPredictor
+
+    @property
+    def REQUIRED_DOCUMENT_FIELDS(self) -> List:
+        base_reqs = [PagesFieldName, TokensFieldName]
+        if self.predictor.preprocessor.config.agg_level == "row":
+            base_reqs.append(RowsFieldName)
+        elif self.predictor.preprocessor.config.agg_level == "block":
+            base_reqs.append(BlocksFieldName)
+        return base_reqs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ predictors = [
     'seqeval==1.2.2',
     'effdet==0.3.0',
     'decontext==0.1.4',
+    'vila==0.5.0'
 ]
 production = [
     'optimum[onnxruntime]==1.4.0'

--- a/tests/test_predictors/test_vila_predictor.py
+++ b/tests/test_predictors/test_vila_predictor.py
@@ -82,17 +82,3 @@ class TestFigureVilaPredictors(unittest.TestCase):
             "allenai/ivila-row-layoutlm-finetuned-s2vl-v2"
         )
         results_with_rows = predictor_with_rows.predict(doc, subpage_per_run=2)
-
-    def test_vila_predictors_with_special_unicode_inputs(self):
-        test_doc_path = self.fixture_path / "unicode-test.json"
-
-        with open(test_doc_path, "r") as fp:
-            res = json.load(fp)
-
-        doc = Document.from_json(res)
-        doc.annotate_images([Image.new("RGB", (596, 842))])
-
-        predictor_with_rows = IVILATokenClassificationPredictor.from_pretrained(
-            "allenai/ivila-row-layoutlm-finetuned-s2vl-v2"
-        )
-        predictor_with_rows.predict(doc, subpage_per_run=2)

--- a/tests/test_predictors/test_vila_predictor.py
+++ b/tests/test_predictors/test_vila_predictor.py
@@ -1,0 +1,98 @@
+"""
+
+@shannons, @kylel
+
+"""
+
+import json
+import os
+import pathlib
+import unittest
+
+from PIL import Image
+
+from papermage.magelib import Document
+from papermage.parsers.pdfplumber_parser import PDFPlumberParser
+from papermage.predictors import IVILATokenClassificationPredictor, LPBlockPredictor
+from papermage.rasterizers.rasterizer import PDF2ImageRasterizer
+
+
+class TestFigureVilaPredictors(unittest.TestCase):
+    @classmethod
+    def setUp(cls):
+        cls.fixture_path = pathlib.Path(__file__).parent.parent / "fixtures"
+
+        cls.DOCBANK_LABEL_MAP = {
+            "0": "paragraph",
+            "1": "title",
+            "2": "equation",
+            "3": "reference",
+            "4": "section",
+            "5": "list",
+            "6": "table",
+            "7": "caption",
+            "8": "author",
+            "9": "abstract",
+            "10": "footer",
+            "11": "date",
+            "12": "figure",
+        }
+        cls.DOCBANK_LABEL_MAP = {int(key): val for key, val in cls.DOCBANK_LABEL_MAP.items()}
+
+        cls.S2VL_LABEL_MAP = {
+            "0": "Title",
+            "1": "Author",
+            "2": "Abstract",
+            "3": "Keywords",
+            "4": "Section",
+            "5": "Paragraph",
+            "6": "List",
+            "7": "Bibliography",
+            "8": "Equation",
+            "9": "Algorithm",
+            "10": "Figure",
+            "11": "Table",
+            "12": "Caption",
+            "13": "Header",
+            "14": "Footer",
+            "15": "Footnote",
+        }
+
+        cls.S2VL_LABEL_MAP = {int(key): val for key, val in cls.S2VL_LABEL_MAP.items()}
+
+    def test_vila_predictors(self):
+        layout_predictor = LPBlockPredictor.from_pretrained("lp://efficientdet/PubLayNet")
+
+        pdfplumber_parser = PDFPlumberParser()
+        rasterizer = PDF2ImageRasterizer()
+
+        doc = pdfplumber_parser.parse(input_pdf_path=self.fixture_path / "1903.10676.pdf")
+        images = rasterizer.rasterize(input_pdf_path=self.fixture_path / "1903.10676.pdf", dpi=72)
+        doc.annotate_images(images)
+
+        layout_regions = layout_predictor.predict(doc)
+        doc.annotate_entity(field_name="blocks", entities=layout_regions)
+
+        predictor_with_blocks = IVILATokenClassificationPredictor.from_pretrained(
+            "allenai/ivila-block-layoutlm-finetuned-docbank"
+        )
+        results_with_blocks = predictor_with_blocks.predict(doc, subpage_per_run=2)
+
+        predictor_with_rows = IVILATokenClassificationPredictor.from_pretrained(
+            "allenai/ivila-row-layoutlm-finetuned-s2vl-v2"
+        )
+        results_with_rows = predictor_with_rows.predict(doc, subpage_per_run=2)
+
+    def test_vila_predictors_with_special_unicode_inputs(self):
+        test_doc_path = self.fixture_path / "unicode-test.json"
+
+        with open(test_doc_path, "r") as fp:
+            res = json.load(fp)
+
+        doc = Document.from_json(res)
+        doc.annotate_images([Image.new("RGB", (596, 842))])
+
+        predictor_with_rows = IVILATokenClassificationPredictor.from_pretrained(
+            "allenai/ivila-row-layoutlm-finetuned-s2vl-v2"
+        )
+        predictor_with_rows.predict(doc, subpage_per_run=2)

--- a/tests/test_recipes/test_core_recipe.py
+++ b/tests/test_recipes/test_core_recipe.py
@@ -41,7 +41,7 @@ def round_all_floats(d: dict):
 
 class TestCoreRecipe(unittest.TestCase):
     def setUp(self):
-        self.fixture_path = pathlib.Path(__file__).parent / "fixtures"
+        self.fixture_path = pathlib.Path(__file__).parent.parent / "fixtures"
         self.recipe = CoreRecipe()
 
     def test_stability(self):

--- a/tests/test_recipes/test_core_recipe.py
+++ b/tests/test_recipes/test_core_recipe.py
@@ -5,6 +5,7 @@
 """
 
 import os
+import pathlib
 import unittest
 
 from papermage.magelib import Document, Entity, Image
@@ -40,88 +41,12 @@ def round_all_floats(d: dict):
 
 class TestCoreRecipe(unittest.TestCase):
     def setUp(self):
-        self.pdfpath = os.path.join(os.path.dirname(__file__), "../fixtures/1903.10676.pdf")
+        self.fixture_path = pathlib.Path(__file__).parent / "tests/fixtures"
         self.recipe = CoreRecipe()
-        self.doc = self.recipe.from_path(pdfpath=self.pdfpath)
 
-    def test_correct_output(self):
-        self.assertEqual(self.doc.symbols[:1000], FIRST_1000_SYMBOLS)
-        self.assertDictEqual(self.doc.pages[0].to_json(), PAGE_JSON)
-        self.assertEqual(self.doc.images[0].to_base64(), BASE64_PAGE_IMAGE)
-        self.assertListEqual(
-            [round_all_floats(t.to_json()) for t in self.doc.tokens[:10]],
-            round_all_floats(FIRST_10_TOKENS_JSON),
-        )
-        self.assertListEqual(
-            [round_all_floats(r.to_json()) for r in self.doc.rows[:5]],
-            round_all_floats(FIRST_5_ROWS_JSON),
-        )
-
-        self.assertListEqual(
-            [round_all_floats(b.to_json()) for b in self.doc.blocks[:3]],
-            round_all_floats(FIRST_3_BLOCKS_JSON),
-        )
-        self.assertListEqual(
-            [round_all_floats(v.to_json()) for v in self.doc.vila_entities[:10]],
-            round_all_floats(FIRST_10_VILA_JSONS),
-        )
-        # self.assertListEqual(
-        #     [round_all_floats(w.to_json()) for w in self.doc.words[895:900]],
-        #     round_all_floats(SEGMENT_OF_WORD_JSONS),
-        # )
-
-    def test_manual_create_using_annotate(self):
-        """
-        This tests whether one can manually reconstruct a Document without using from_json().
-        Annotations on a Document are order-invariant once created, so you can see this since the
-        fields are being annotated in a different order than they were computed.
-        """
-        doc_json = self.doc.to_json(with_images=True)
-
-        doc2 = Document(symbols=doc_json["symbols"], metadata=doc_json["metadata"])
-        assert doc2.symbols == doc_json["symbols"] == self.doc.symbols
-        assert doc2.metadata.to_json() == doc_json["metadata"] == self.doc.metadata.to_json()
-
-        images = [Image.from_base64(img) for img in doc_json["images"]]
-        doc2.annotate_images(images)
-        assert doc2.images[0].to_base64() == doc_json["images"][0] == self.doc.images[0].to_base64()
-
-        rows = [Entity.from_json(entity_json=r) for r in doc_json["entities"]["rows"]]
-        doc2.annotate_entity(field_name="rows", entities=rows)
-        assert (
-            [r.to_json() for r in doc2.rows]
-            == doc_json["entities"]["rows"]
-            == [r.to_json() for r in self.doc.rows]
-        )
-
-        vila_entities = [Entity.from_json(entity_json=v) for v in doc_json["entities"]["vila_entities"]]
-        doc2.annotate_entity(field_name="vila_entities", entities=vila_entities)
-        assert (
-            [v.to_json() for v in doc2.vila_entities]
-            == doc_json["entities"]["vila_entities"]
-            == [v.to_json() for v in self.doc.vila_entities]
-        )
-
-        # words = [Entity.from_json(entity_json=w) for w in doc_json["entities"]["words"]]
-        # doc2.annotate(words=words)
-        # assert (
-        #     [w.to_json() for w in doc2.words]
-        #     == doc_json["entities"]["words"]
-        #     == [w.to_json() for w in self.doc.words]
-        # )
-
-        tokens = [Entity.from_json(entity_json=t) for t in doc_json["entities"]["tokens"]]
-        doc2.annotate_entity(field_name="tokens", entities=tokens)
-        assert (
-            [t.to_json() for t in doc2.tokens]
-            == doc_json["entities"]["tokens"]
-            == [t.to_json() for t in self.doc.tokens]
-        )
-
-        blocks = [Entity.from_json(entity_json=b) for b in doc_json["entities"]["blocks"]]
-        doc2.annotate_entity(field_name="blocks", entities=blocks)
-        assert (
-            [b.to_json() for b in doc2.blocks]
-            == doc_json["entities"]["blocks"]
-            == [b.to_json() for b in self.doc.blocks]
-        )
+    def test_stability(self):
+        doc = self.recipe.from_path(pdfpath=self.fixture_path / "1903.10676.pdf")
+        doc = self.recipe.from_path(pdfpath=self.fixture_path / "2304.02623v1.pdf")
+        doc = self.recipe.from_path(pdfpath=self.fixture_path / "2020.acl-main.447.pdf")
+        doc = self.recipe.from_path(pdfpath=self.fixture_path / "4be952924cd565488b4a239dc6549095029ee578.pdf")
+        doc = self.recipe.from_path(pdfpath=self.fixture_path / "2023.eacl-main.121.pdf")

--- a/tests/test_recipes/test_core_recipe.py
+++ b/tests/test_recipes/test_core_recipe.py
@@ -41,7 +41,7 @@ def round_all_floats(d: dict):
 
 class TestCoreRecipe(unittest.TestCase):
     def setUp(self):
-        self.fixture_path = pathlib.Path(__file__).parent / "tests/fixtures"
+        self.fixture_path = pathlib.Path(__file__).parent / "fixtures"
         self.recipe = CoreRecipe()
 
     def test_stability(self):


### PR DESCRIPTION
pretty much exact port from `mmda`. testing is fine on pdf fixtures works

```
import json
import os
import pathlib
import unittest

from papermage.magelib import Document, Entity, Metadata, Span
from papermage.recipes import CoreRecipe

fixture_path = pathlib.Path(__file__).parent / "tests/fixtures"

recipe = CoreRecipe()
doc = recipe.from_path(pdfpath=fixture_path / "1903.10676.pdf") 
doc = recipe.from_path(pdfpath=fixture_path / "2304.02623v1.pdf")
doc = recipe.from_path(pdfpath=fixture_path / "2020.acl-main.447.pdf")
doc = recipe.from_path(pdfpath=fixture_path / "4be952924cd565488b4a239dc6549095029ee578.pdf") 
doc = recipe.from_path(pdfpath=fixture_path / "2023.eacl-main.121.pdf")
```