### PR TITLE
Format and update decontext

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ predictors = [
     'wandb==0.15.7',
     'seqeval==1.2.2',
     'effdet==0.3.0',
-    'decontext==0.1.5',
+    'decontext@git+https://github.com/bnewm0609/qa-decontextualization@cache_invalidation',
     'vila==0.5.0'
 ]
 production = [

--- a/tests/test_predictors/test_span_qa_predictor.py
+++ b/tests/test_predictors/test_span_qa_predictor.py
@@ -58,19 +58,31 @@ class TestSpanQAPredictor(unittest.TestCase):
         annotations = self.span_qa_predictor.predict(doc=self.doc)
 
         assert annotations[0].metadata["type"] == "answer"
-        assert annotations[0].metadata["answer"] == 'The term "AI-assisted writing" refers to the utilization of Language Models (LLMs) to aid in writing tasks, as specified in the provided text.'
+        assert (
+            annotations[0].metadata["answer"]
+            == 'The term "AI-assisted writing" refers to the utilization of Language Models (LLMs) to aid in writing tasks, as specified in the provided text.'
+        )
         assert annotations[0].metadata["question"] == "What does this mean?"
 
         self.doc.annotate_entity(field_name="context_with_span", entities=[annotations[1]])
         assert annotations[1].metadata["type"] == "context_with_span"
-        assert annotations[1].text == "1 In the remainder of this work, unless otherwise specified, AI-assisted writing refers to the use of LLMs to support writing."
+        assert (
+            annotations[1].text
+            == "1 In the remainder of this work, unless otherwise specified, AI-assisted writing refers to the use of LLMs to support writing."
+        )
 
         self.doc.annotate_entity(field_name="evidence", entities=annotations[2:5])
         assert annotations[2].metadata["type"] == "evidence"
         assert annotations[2].text == "knowledge or information. For example, this could be researchers"
 
         assert annotations[3].metadata["type"] == "evidence"
-        assert annotations[3].text == "Position-Sensitive Definitions of Terms and Symbols. Proceedings of the 2021 CHI Conference on Human Factors in Computing Systems (2020)."
+        assert (
+            annotations[3].text
+            == "Position-Sensitive Definitions of Terms and Symbols. Proceedings of the 2021 CHI Conference on Human Factors in Computing Systems (2020)."
+        )
 
         assert annotations[4].metadata["type"] == "evidence"
-        assert annotations[4].text == "[1] Griffin Adams, Emily Alsentzer, Mert Ketenci, Jason Zucker, and Noémie El- hadad. 2021. What’s in a Summary? Laying the Groundwork for Advances in"
+        assert (
+            annotations[4].text
+            == "[1] Griffin Adams, Emily Alsentzer, Mert Ketenci, Jason Zucker, and Noémie El- hadad. 2021. What’s in a Summary? Laying the Groundwork for Advances in"
+        )


### PR DESCRIPTION
For API SpanQA, you can clear the cache with: `span_qa_predictor.retrieval_qa_step.model.cache.remove_all_unsafe_no_confirm`.

You can also invalidate the cache for a prediction with: 
```python
from decontext.cache import CacheState

span_qa_predictor.retrieval_qa_step.cache_state=CacheState.INVALIDATE
```
before running `span_qa_predictor.run`.

See the `decontext` [README](https://github.com/bnewm0609/qa-decontextualization) for more information on how to use `CacheState`
