### PR TITLE
Remove Restriction on Pandas Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # papermage
-force CI
+
 ### Setup
 
 ```python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # papermage
-
+force CI
 ### Setup
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
         'requests',
         'numpy>=1.23.2',
         'scipy>=1.9.0',
-        'pandas<2',
         'ncls==0.0.68',
         'necessary>=0.3.2',
         'grobid-client-python==0.0.5',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'papermage'
-version = '0.15.1'
+version = '0.16.0'
 description = 'Papermage. Casting magic over scientific PDFs.'
 license = {text = 'Apache-2.0'}
 readme = 'README.md'


### PR DESCRIPTION
Hello there!

I noticed that `papermage` currently restricts the version of `pandas` to be `pandas<2`, however I don't believe the project explicitly imports and uses the package. This is a bit of a challenge for developers using this project because a lot of other projects are upgrading to `pandas>=2` to make use of new functionalities, which causes issues in dependency resolution.

I created a fork in which I removed the restriction, ran the CI pipeline, and found that the builds for Python 3.8, 3.9, and 3.11 all passed. As such -- unless there is a good reason for keeping the version at `pandas<2` (which there very might well be) -- I was wondering if you would be willing to remove the restriction to make it easier for downstream developers to incorporate your awesome work into our project(s)! 